### PR TITLE
Fix `dind` version to match CircleCI Docker version

### DIFF
--- a/updater/Dockerfile
+++ b/updater/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:dind
+FROM docker:18.09.3-dind
 
 RUN apk update
 RUN apk add curl python3 git bash dos2unix openssh build-base python3-dev

--- a/updater/cmd.bash
+++ b/updater/cmd.bash
@@ -13,7 +13,7 @@ set -x
 
 export COMPOSE_INTERACTIVE_NO_CLI=1
 
-# dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375 &> /dev/null &
+dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375 &> /dev/null &
 
 git clone --depth=1 "$REPO_POKEAPI" pokeapi
 git clone --depth=1 "$REPO_DATA" api-data

--- a/updater/cmd.bash
+++ b/updater/cmd.bash
@@ -13,7 +13,7 @@ set -x
 
 export COMPOSE_INTERACTIVE_NO_CLI=1
 
-dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375 &> /dev/null &
+# dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375 &> /dev/null &
 
 git clone --depth=1 "$REPO_POKEAPI" pokeapi
 git clone --depth=1 "$REPO_DATA" api-data


### PR DESCRIPTION
CircleCI uses Docker 18.09.3

https://circleci.com/docs/2.0/configuration-reference/#available-machine-images

`Dind` only works when deployed on the same version engine. So we should ensure we are using `18.09.3`