### PR TITLE
Enable staging deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,14 @@ executors:
 
 commands:
   ditto-transform:
-    description: Run Ditto in order to transform the base URL to https://pokeapi.co instead of localhost
+    description: Run Ditto in order to transform the BASE_URL instead of http://localhost
     steps:
-      - run: pip install --user -r requirements.txt
-      - run: bash -x scripts/transform.sh
+      - run: 
+          name: Install requirements.txt
+          command: pip install --user -r requirements.txt
+      - run: 
+          name: Transform api-data's JSON files to have the correct BASE_URL instead of http://localhost
+          command: bash -x scripts/transform.sh
 
 jobs:
   test:
@@ -23,11 +27,15 @@ jobs:
     steps:
       - checkout
       - ditto-transform
-      - run: tar czf _gen.tar.gz _gen/*
+      - run: 
+          name: Pack the transofrmed data in a .tar.gz
+          command: tar czf _gen.tar.gz _gen/*
       - store_artifacts:
           path: _gen.tar.gz
       # Trigger a new build of the deploy job of the deploy project
-      - run: 'curl --header "Content-Type: application/json" --data "{\"build_parameters\": {\"deploy_location\": \"$CIRCLE_BRANCH\", \"CIRCLE_JOB\": \"deploy\"}}" --request POST "https://circleci.com/api/v1.1/project/github/PokeAPI/deploy/tree/test-staging?circle-token=$CIRCLECI_API_TOKEN"'
+      - run: 
+          name: Trigger a deploy of the deploy project passing the desired environment/location to deploy to
+          command: 'curl --header "Content-Type: application/json" --data "{\"build_parameters\": {\"deploy_location\": \"$CIRCLE_BRANCH\", \"CIRCLE_JOB\": \"deploy\"}}" --request POST "https://circleci.com/api/v1.1/project/github/PokeAPI/deploy/tree/test-staging?circle-token=$CIRCLECI_API_TOKEN"'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       # Trigger a new build of the deploy job of the deploy project
       - run: 
           name: Trigger a deploy of the deploy project passing the desired environment/location to deploy to
-          command: 'curl --header "Content-Type: application/json" --data "{\"build_parameters\": {\"deploy_location\": \"$CIRCLE_BRANCH\", \"CIRCLE_JOB\": \"deploy\"}}" --request POST "https://circleci.com/api/v1.1/project/github/PokeAPI/deploy/tree/test-staging?circle-token=$CIRCLECI_API_TOKEN"' # # TODO: replace `test-staging` with `master`
+          command: 'curl --header "Content-Type: application/json" --data "{\"build_parameters\": {\"deploy_location\": \"$CIRCLE_BRANCH\", \"CIRCLE_JOB\": \"deploy\"}}" --request POST "https://circleci.com/api/v1.1/project/github/PokeAPI/deploy/tree/master?circle-token=$CIRCLECI_API_TOKEN"'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,12 +10,7 @@ commands:
     description: Run Ditto in order to transform the base URL to https://pokeapi.co instead of localhost
     steps:
       - run: pip install --user -r requirements.txt
-      - run:
-          command: |
-            ~/.local/bin/ditto transform \
-              --base-url='https://pokeapi.co' \
-              --src-dir=data \
-              --dest-dir=_gen
+      - run: bash scripts/transform.sh
 
 jobs:
   test:
@@ -31,7 +26,8 @@ jobs:
       - run: tar czf _gen.tar.gz _gen/*
       - store_artifacts:
           path: _gen.tar.gz
-      - run: "curl -X POST --header \"Content-Type: application/json\" https://circleci.com/api/v1.1/project/github/PokeAPI/deploy/build?circle-token=$CIRCLECI_API_TOKEN"
+      # Trigger a new build of the deploy job of the deploy project
+      - run: curl --header "Content-Type: application/json" --data "{\"build_parameters\": {\"deploy_location\": \"$CIRCLE_BRANCH\", \"CIRCLE_JOB\": \"deploy\"}}" --request POST "https://circleci.com/api/v1.1/project/github/PokeAPI/deploy/tree/test-staging?circle-token=$CIRCLECI_API_TOKEN"
 
 workflows:
   version: 2
@@ -43,4 +39,6 @@ workflows:
             - test
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - store_artifacts:
           path: _gen.tar.gz
       # Trigger a new build of the deploy job of the deploy project
-      - run: curl --header "Content-Type: application/json" --data "{\"build_parameters\": {\"deploy_location\": \"$CIRCLE_BRANCH\", \"CIRCLE_JOB\": \"deploy\"}}" --request POST "https://circleci.com/api/v1.1/project/github/PokeAPI/deploy/tree/test-staging?circle-token=$CIRCLECI_API_TOKEN"
+      - run: 'curl --header "Content-Type: application/json" --data "{\"build_parameters\": {\"deploy_location\": \"$CIRCLE_BRANCH\", \"CIRCLE_JOB\": \"deploy\"}}" --request POST "https://circleci.com/api/v1.1/project/github/PokeAPI/deploy/tree/test-staging?circle-token=$CIRCLECI_API_TOKEN"'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ commands:
     description: Run Ditto in order to transform the base URL to https://pokeapi.co instead of localhost
     steps:
       - run: pip install --user -r requirements.txt
-      - run: bash scripts/transform.sh
+      - run: bash -x scripts/transform.sh
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       # Trigger a new build of the deploy job of the deploy project
       - run: 
           name: Trigger a deploy of the deploy project passing the desired environment/location to deploy to
-          command: 'curl --header "Content-Type: application/json" --data "{\"build_parameters\": {\"deploy_location\": \"$CIRCLE_BRANCH\", \"CIRCLE_JOB\": \"deploy\"}}" --request POST "https://circleci.com/api/v1.1/project/github/PokeAPI/deploy/tree/test-staging?circle-token=$CIRCLECI_API_TOKEN"'
+          command: 'curl --header "Content-Type: application/json" --data "{\"build_parameters\": {\"deploy_location\": \"$CIRCLE_BRANCH\", \"CIRCLE_JOB\": \"deploy\"}}" --request POST "https://circleci.com/api/v1.1/project/github/PokeAPI/deploy/tree/test-staging?circle-token=$CIRCLECI_API_TOKEN"' # # TODO: replace `test-staging` with `master`
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - checkout
       - ditto-transform
       - run: 
-          name: Pack the transofrmed data in a .tar.gz
+          name: Pack the transformed data in a .tar.gz
           command: tar czf _gen.tar.gz _gen/*
       - store_artifacts:
           path: _gen.tar.gz

--- a/scripts/transform.sh
+++ b/scripts/transform.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Runs in CircleCI
+# Replaces all the http://localhost links of api-data to match the corresponding deployment location.
+
+if [ "${CIRCLE_BRANCH}" = 'master' ]; then # https://stackoverflow.com/a/2013589/3482533
+    ~/.local/bin/ditto transform --base-url='https://pokeapi.co' --src-dir=data --dest-dir=_gen
+elif [ "${CIRCLE_BRANCH}" = 'test-staging' ]; then # Change to `staging`
+    ~/.local/bin/ditto transform --base-url='https://pokeapi-test-b6137.firebaseapp.com' --src-dir=data --dest-dir=_gen
+fi

--- a/scripts/transform.sh
+++ b/scripts/transform.sh
@@ -4,6 +4,6 @@
 
 if [ "${CIRCLE_BRANCH}" = 'master' ]; then # https://stackoverflow.com/a/2013589/3482533
     ~/.local/bin/ditto transform --base-url='https://pokeapi.co' --src-dir=data --dest-dir=_gen
-elif [ "${CIRCLE_BRANCH}" = 'test-staging' ]; then # Change to `staging`
+elif [ "${CIRCLE_BRANCH}" = 'staging' ]; then
     ~/.local/bin/ditto transform --base-url='https://pokeapi-test-b6137.firebaseapp.com' --src-dir=data --dest-dir=_gen
 fi

--- a/updater/cmd.bash
+++ b/updater/cmd.bash
@@ -16,7 +16,7 @@ export COMPOSE_INTERACTIVE_NO_CLI=1
 dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375 &> /dev/null &
 
 git clone --depth=1 "$REPO_POKEAPI" pokeapi
-git clone "$REPO_DATA" api-data
+git clone --depth=1 "$REPO_DATA" api-data
 
 # set up the pokeapi side
 cd pokeapi
@@ -30,10 +30,9 @@ docker-compose exec -T app sh -c 'echo "from data.v2.build import build_all; bui
 
 # set up the data side
 cd ../api-data
-# git branch -D "$BRANCH_NAME" || true # TODO: uncomment
-# git branch "$BRANCH_NAME"
-# git checkout "$BRANCH_NAME"
-git checkout "$BRANCH_NAME" # TODO: remove
+git branch -D "$BRANCH_NAME" || true
+git branch "$BRANCH_NAME"
+git checkout "$BRANCH_NAME"
 
 pip install -r requirements.txt
 rm -r ./data

--- a/updater/cmd.bash
+++ b/updater/cmd.bash
@@ -16,7 +16,7 @@ export COMPOSE_INTERACTIVE_NO_CLI=1
 dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375 &> /dev/null &
 
 git clone --depth=1 "$REPO_POKEAPI" pokeapi
-git clone --depth=1 "$REPO_DATA" api-data
+git clone "$REPO_DATA" api-data
 
 # set up the pokeapi side
 cd pokeapi
@@ -30,8 +30,9 @@ docker-compose exec -T app sh -c 'echo "from data.v2.build import build_all; bui
 
 # set up the data side
 cd ../api-data
-git branch -D "$BRANCH_NAME" || true
-git branch "$BRANCH_NAME"
+# git branch -D "$BRANCH_NAME" || true
+# git branch "$BRANCH_NAME"
+# git checkout "$BRANCH_NAME"
 git checkout "$BRANCH_NAME"
 
 pip install -r requirements.txt

--- a/updater/cmd.bash
+++ b/updater/cmd.bash
@@ -30,10 +30,10 @@ docker-compose exec -T app sh -c 'echo "from data.v2.build import build_all; bui
 
 # set up the data side
 cd ../api-data
-# git branch -D "$BRANCH_NAME" || true
+# git branch -D "$BRANCH_NAME" || true # TODO: uncomment
 # git branch "$BRANCH_NAME"
 # git checkout "$BRANCH_NAME"
-git checkout "$BRANCH_NAME"
+git checkout "$BRANCH_NAME" # TODO: remove
 
 pip install -r requirements.txt
 rm -r ./data


### PR DESCRIPTION


This PR allows invoking in a conditional manner a new _deploy_ job present in the `PokeAPI/deploy` CircleCI configuration. This job will automatically deploy the `api-data` data to our productive environment (pokeapi.co) or to a new staging environment.  The job will be invoked only when the `master` or `staging` branches of this repository are pushed to. If the `master` is getting pushed then the `master` branch will be deployed in the productive environment. Viceversa, if the `staging` branch is pushed, then the `staging` branch will be deployed in the staging environment.

A more descriptive and general overview is detailed in this https://github.com/PokeAPI/pokeapi/pull/488 PR.


---

This PR is linked to the following PRs: 
- https://github.com/PokeAPI/deploy/pull/10 
- https://github.com/PokeAPI/pokeapi.co/pull/76 
- https://github.com/PokeAPI/pokeapi/pull/488

__When https://github.com/PokeAPI/deploy/pull/10 will be merged we need to change `.circleci/config.yml#38`, `updater/cmd.bash#33`, `updater/cmd.bash#36`__

This PR should be merged after https://github.com/PokeAPI/deploy/pull/10