### PR TITLE
Updater refactor

### DIFF
--- a/updater/cmd.bash
+++ b/updater/cmd.bash
@@ -6,6 +6,7 @@
 [ -z "${REPO_POKEAPI}" ] && { echo "Need to set REPO_POKEAPI"; exit 1; }
 [ -z "${REPO_DATA}" ] && { echo "Need to set REPO_DATA"; exit 1; }
 [ -z "${BRANCH_NAME}" ] && { echo "Need to set BRANCH_NAME"; exit 1; }
+[ -z "${REPO_POKEAPI_CHECKOUT_OBJECT:=master}" ] && { echo "REPO_POKEAPI_CHECKOUT_OBJECT not set, defaulting to \`master\`"; }
 
 set -e
 set -o pipefail
@@ -15,11 +16,14 @@ export COMPOSE_INTERACTIVE_NO_CLI=1
 
 dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375 &> /dev/null &
 
-git clone --recurse-submodules "$REPO_POKEAPI" pokeapi
+git clone "$REPO_POKEAPI" pokeapi
 git clone --depth=1 "$REPO_DATA" api-data
 
 # set up the pokeapi side
 cd pokeapi
+git checkout "$REPO_POKEAPI_CHECKOUT_OBJECT"
+git submodule init
+git submodule update --remote
 
 docker volume create --name=redis_data
 docker volume create --name=pg_data

--- a/updater/cmd.bash
+++ b/updater/cmd.bash
@@ -49,5 +49,8 @@ ditto analyze --data-dir ./data
 git add data
 git config user.name "$COMMIT_NAME"
 git config user.email "$COMMIT_EMAIL"
-git commit -m "$COMMIT_MESSAGE"
+if ! git commit -m "$COMMIT_MESSAGE"; then
+    echo "The generated data doesn't bring any updates"
+    exit 2
+fi
 git push -fu origin "$BRANCH_NAME"


### PR DESCRIPTION
- Allow to checkout different objects of the pokeapi repo. So, in our pipeline, we can check out the `staging` branch and deploy it.
- Fail with exit code `2` in case the generated data is the same as the one present in the repo.
- Check out submodules