### PR TITLE
Setting is_legendary flag for Ruinous Quartet as true

### DIFF
--- a/data/api/v2/pokemon-species/1001/index.json
+++ b/data/api/v2/pokemon-species/1001/index.json
@@ -41,7 +41,7 @@
     "hatch_counter": 50,
     "id": 1001,
     "is_baby": false,
-    "is_legendary": false,
+    "is_legendary": true,
     "is_mythical": false,
     "name": "wo-chien",
     "names": [

--- a/data/api/v2/pokemon-species/1002/index.json
+++ b/data/api/v2/pokemon-species/1002/index.json
@@ -41,7 +41,7 @@
     "hatch_counter": 50,
     "id": 1002,
     "is_baby": false,
-    "is_legendary": false,
+    "is_legendary": true,
     "is_mythical": false,
     "name": "chien-pao",
     "names": [

--- a/data/api/v2/pokemon-species/1003/index.json
+++ b/data/api/v2/pokemon-species/1003/index.json
@@ -41,7 +41,7 @@
     "hatch_counter": 50,
     "id": 1003,
     "is_baby": false,
-    "is_legendary": false,
+    "is_legendary": true,
     "is_mythical": false,
     "name": "ting-lu",
     "names": [

--- a/data/api/v2/pokemon-species/1004/index.json
+++ b/data/api/v2/pokemon-species/1004/index.json
@@ -41,7 +41,7 @@
     "hatch_counter": 50,
     "id": 1004,
     "is_baby": false,
-    "is_legendary": false,
+    "is_legendary": true,
     "is_mythical": false,
     "name": "chi-yu",
     "names": [


### PR DESCRIPTION
Fixing issue 157 `https://github.com/PokeAPI/pokedex/issues/157`