### PR TITLE
Use venv

### DIFF
--- a/updater/cmd.bash
+++ b/updater/cmd.bash
@@ -33,7 +33,8 @@ git checkout "$REPO_APIDATA_CHECKOUT_OBJECT"
 git branch -D "$BRANCH_NAME" || true
 git branch "$BRANCH_NAME"
 git checkout "$BRANCH_NAME"
-
+python -m venv .venv
+source .venv/bin/activate
 pip install 'pokeapi-ditto==1.0.3'
 rm -rf ./data
 ditto clone --src-url http://localhost/ --dest-dir ./data


### PR DESCRIPTION
Newer Ubuntu requires the use of `venv` when installing packages. 

https://github.com/PokeAPI/api-data/actions/runs/11349047729/job/31564242160?pr=260#step:3:1028

https://stackoverflow.com/questions/75602063/pip-install-r-requirements-txt-is-failing-this-environment-is-externally-mana